### PR TITLE
feat: Add Homebrew, asdf, and Terraform to DevContainer

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -23,8 +23,12 @@ RUN apt update && apt install -y less \
   curl \
   squid \
   openssl \
-  locales && \
+  locales \
+  software-properties-common && \
   locale-gen en_US.UTF-8
+
+# Create linuxbrew home directory and set permissions
+RUN mkdir -p /home/linuxbrew && chown -R node:node /home/linuxbrew
 
 # Set locale environment variables
 ENV LANG=en_US.UTF-8
@@ -72,6 +76,14 @@ RUN ARCH=$(dpkg --print-architecture) && \
 # Set up non-root user
 USER node
 
+# Install Homebrew as node user
+RUN NONINTERACTIVE=1 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+
+# Set up Homebrew environment
+ENV PATH="/home/linuxbrew/.linuxbrew/bin:$PATH"
+RUN echo 'eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"' >> ~/.bashrc && \
+  echo 'eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"' >> ~/.zshrc
+
 # Install global packages
 ENV NPM_CONFIG_PREFIX=/usr/local/share/npm-global
 ENV PATH=$PATH:/usr/local/share/npm-global/bin
@@ -90,6 +102,20 @@ RUN sh -c "$(wget -O- https://github.com/deluan/zsh-in-docker/releases/download/
 
 # Install Claude
 RUN npm install -g @anthropic-ai/claude-code
+
+# Install asdf via Homebrew
+RUN /home/linuxbrew/.linuxbrew/bin/brew install asdf && \
+  echo 'export PATH="/home/node/.asdf/shims:$PATH"' >> ~/.bashrc && \
+  echo '. "/home/linuxbrew/.linuxbrew/opt/asdf/libexec/asdf.sh"' >> ~/.bashrc && \
+  echo 'export PATH="/home/node/.asdf/shims:$PATH"' >> ~/.zshrc && \
+  echo '. "/home/linuxbrew/.linuxbrew/opt/asdf/libexec/asdf.sh"' >> ~/.zshrc
+
+# Install terraform via asdf
+RUN eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)" && \
+  asdf plugin add terraform https://github.com/asdf-community/asdf-hashicorp.git && \
+  asdf install terraform latest && \
+  asdf set --home terraform latest && \
+  asdf reshim
 
 # Copy and set up proxy scripts
 COPY squid.conf /usr/local/bin/


### PR DESCRIPTION
## Summary
- Install Homebrew (Linuxbrew) for better package management on Linux containers
- Install asdf via Homebrew for runtime version management
- Install Terraform latest version through asdf with automatic global configuration

## Changes
1. **Homebrew Installation**
   - Install Linuxbrew as the `node` user (not root)
   - Configure shell environments (bash/zsh) with Homebrew PATH

2. **asdf Setup**
   - Install asdf through Homebrew
   - Configure asdf initialization in shell profiles
   - Add asdf shims to PATH

3. **Terraform Installation**
   - Install Terraform via asdf plugin
   - Use `asdf install terraform latest` to get the latest version
   - Use `asdf set --home terraform latest` to set as global default
   - No manual .tool-versions file needed

## Test plan
- [x] Docker build succeeds
- [x] Terraform command is available in container
- [x] asdf shows Terraform as installed and current
- [x] Version management works correctly

```bash
# Build and test
docker build -t test-terraform .devcontainer/
docker run --rm test-terraform bash -c "source ~/.bashrc && terraform version"
docker run --rm test-terraform bash -c "asdf current"
```

## Benefits
- Terraform available for infrastructure as code development
- Version management through asdf allows easy switching between Terraform versions
- Homebrew provides a consistent package management experience
- Automatic setup of latest Terraform version as default

🤖 Generated with [Claude Code](https://claude.ai/code)